### PR TITLE
Automated PR: Cookstyle Changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the cpu cookbook.
 
 ## Unreleased
 
+- resolved cookstyle error: resources/affinity.rb:32:1 refactor: `Chef/Modernize/ClassEvalActionClass`
+- resolved cookstyle error: resources/nice.rb:30:1 refactor: `Chef/Modernize/ClassEvalActionClass`
 ## 2.1.2 - *2021-08-31*
 
 - Standardise files with files in sous-chefs/repo-management

--- a/resources/affinity.rb
+++ b/resources/affinity.rb
@@ -29,6 +29,6 @@ action :set do
   end
 end
 
-action_class.class_eval do
+action_class do
   include CpuCookbook::Helpers
 end

--- a/resources/nice.rb
+++ b/resources/nice.rb
@@ -27,6 +27,6 @@ action :set do
   end
 end
 
-action_class.class_eval do
+action_class do
   include CpuCookbook::Helpers
 end


### PR DESCRIPTION
Hey!
I ran Cookstyle 7.25.6 against this repo and here are the results.
This repo was selected due to the topics of chef-cookbook

## Changes

### Issues found and resolved with resources/affinity.rb

 - 32:1 refactor: `Chef/Modernize/ClassEvalActionClass` - In Chef Infra Client 12.9 and later it is no longer necessary to call the class_eval method on the action class block. (https://docs.chef.io/workstation/cookstyle/chef_modernize_classevalactionclass)

### Issues found and resolved with resources/nice.rb

 - 30:1 refactor: `Chef/Modernize/ClassEvalActionClass` - In Chef Infra Client 12.9 and later it is no longer necessary to call the class_eval method on the action class block. (https://docs.chef.io/workstation/cookstyle/chef_modernize_classevalactionclass)