### PR TITLE
ci: use sous-chefs workflows 8.0.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ name: ci
 
 jobs:
   lint-unit:
-    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@6.0.0
+    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@8.0.1
     permissions:
       actions: write
       checks: write

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -6,4 +6,4 @@ name: conventional-commits
 
 jobs:
   conventional-commits:
-    uses: sous-chefs/.github/.github/workflows/conventional-commits.yml@6.0.0
+    uses: sous-chefs/.github/.github/workflows/conventional-commits.yml@8.0.1

--- a/.github/workflows/prevent-file-change.yml
+++ b/.github/workflows/prevent-file-change.yml
@@ -6,6 +6,6 @@ name: prevent-file-change
 
 jobs:
   prevent-file-change:
-    uses: sous-chefs/.github/.github/workflows/prevent-file-change.yml@6.0.0
+    uses: sous-chefs/.github/.github/workflows/prevent-file-change.yml@8.0.1
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   release:
-    uses: sous-chefs/.github/.github/workflows/release-cookbook.yml@6.0.0
+    uses: sous-chefs/.github/.github/workflows/release-cookbook.yml@8.0.1
     secrets:
       token: ${{ secrets.PORTER_GITHUB_TOKEN }}
       supermarket_user: ${{ secrets.CHEF_SUPERMARKET_USER }}


### PR DESCRIPTION
Update reusable Sous Chefs workflow calls to 8.0.1.

This removes local workflow trusted-author overrides so repositories inherit the central policy from sous-chefs/.github.