### PR TITLE
chore: migrate dependency resolution to Policyfile

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v7
-      - name: Install Chef
-        uses: actionshub/chef-install@main
+      - name: Install Cinc Workstation
+        uses: sous-chefs/.github/.github/actions/install-workstation@8.0.4
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,7 @@ doc/
 rdoc
 
 # chef infra stuff
-Berksfile.lock
+Policyfile.lock.json
 .kitchen
 kitchen.local.yml
 vendor/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,15 @@
-# Limitations
+# AGENTS.md
+
+## Cookbook Purpose
+
+Installs and manages CPU frequency tooling and runtime CPU settings.
+
+## Agent Findings
+
+* This cookbook is in an incremental modernization pass. Preserve existing public recipes and attributes unless a later full migration is explicitly selected.
+* Dependency management should use `Policyfile.rb`; do not reintroduce Berkshelf.
+
+## Known Limitations
 
 ## Package Availability
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,26 +15,26 @@ Installs and manages CPU frequency tooling and runtime CPU settings.
 
 ### APT (Debian/Ubuntu)
 
-- Debian 12 (Bookworm): `cpufrequtils` is available in the Debian package archive.
-- Ubuntu 22.04 (Jammy): `cpufrequtils` is available in Ubuntu Universe.
-- Ubuntu 24.04 (Noble): `cpufrequtils` is available in Ubuntu Universe.
+* Debian 12 (Bookworm): `cpufrequtils` is available in the Debian package archive.
+* Ubuntu 22.04 (Jammy): `cpufrequtils` is available in Ubuntu Universe.
+* Ubuntu 24.04 (Noble): `cpufrequtils` is available in Ubuntu Universe.
 
 ### DNF/YUM (RHEL family and Fedora)
 
-- Red Hat-family and Fedora documentation use the `cpupower` tooling to inspect and set governors rather than `cpufrequtils` / `cpufreq-set`.
-- The current cookbook implementation uses `cpufrequtils` and `cpufreq-set`, so this cookbook should not claim support for Red Hat-family, Fedora, Amazon Linux, or openSUSE platforms without a separate implementation path.
+* Red Hat-family and Fedora documentation use the `cpupower` tooling to inspect and set governors rather than `cpufrequtils` / `cpufreq-set`.
+* The current cookbook implementation uses `cpufrequtils` and `cpufreq-set`, so this cookbook should not claim support for Red Hat-family, Fedora, Amazon Linux, or openSUSE platforms without a separate implementation path.
 
 ## Architecture Limitations
 
-- Debian package metadata lists `cpufrequtils` for Bookworm on multiple architectures, including `amd64` and `arm64`.
-- Ubuntu package metadata lists `cpufrequtils` for Jammy and Noble on `amd64`, `arm64`, `armhf`, and `s390x`.
+* Debian package metadata lists `cpufrequtils` for Bookworm on multiple architectures, including `amd64` and `arm64`.
+* Ubuntu package metadata lists `cpufrequtils` for Jammy and Noble on `amd64`, `arm64`, `armhf`, and `s390x`.
 
 ## Source/Compiled Installation
 
-- This cookbook does not implement a source-build path.
-- The current resource model assumes distro-packaged `cpufrequtils` and the presence of `cpufreq-info` / `cpufreq-set`.
+* This cookbook does not implement a source-build path.
+* The current resource model assumes distro-packaged `cpufrequtils` and the presence of `cpufreq-info` / `cpufreq-set`.
 
 ## Known Issues
 
-- EOL platforms still present in the old test matrix included CentOS Linux 7/8, CentOS Stream 8, Debian 9/10, Ubuntu 18.04/20.04, Oracle Linux 7, and Scientific Linux.
-- openSUSE Leap 15.6 reaches end of life on 30 April 2026, so it should not be added as an ongoing support target in this cookbook.
+* EOL platforms still present in the old test matrix included CentOS Linux 7/8, CentOS Stream 8, Debian 9/10, Ubuntu 18.04/20.04, Oracle Linux 7, and Scientific Linux.
+* openSUSE Leap 15.6 reaches end of life on 30 April 2026, so it should not be added as an ongoing support target in this cookbook.

--- a/Berksfile
+++ b/Berksfile
@@ -1,7 +1,0 @@
-source 'https://supermarket.chef.io'
-
-metadata
-
-group :integration do
-  cookbook 'test', path: './test/cookbooks/test'
-end

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+name 'cpu'
+
+run_list 'test::default'
+
+cookbook 'cpu', path: '.'
+cookbook 'test', path: './test/cookbooks/test'
+
+Dir.children('./test/cookbooks/test/recipes').grep(/\.rb\z/).sort.each do |recipe|
+  recipe_name = File.basename(recipe, '.rb')
+
+  named_run_list recipe_name.to_sym, 'test::' + recipe_name
+end

--- a/chefignore
+++ b/chefignore
@@ -83,12 +83,9 @@ test/*
 */.hg/*
 */.svn/*
 
-# Berkshelf #
-#############
-Berksfile
-Berksfile.lock
 cookbooks/*
 tmp
+Policyfile.lock.json
 
 # Bundler #
 ###########

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 
 RSpec.configure do |config|
   config.color = true               # Use color in STDOUT


### PR DESCRIPTION
## Summary
- migrate dependency resolution from Berksfile to Policyfile
- update ChefSpec setup to use Policyfile resolution
- update Copilot setup to install Chef Workstation 8.0.4 and run chef install Policyfile.rb
- move cookbook limitations into AGENTS.md where present

## Verification
- chef install Policyfile.rb
- cookstyle
- kitchen list
- /opt/chef-workstation/embedded/bin/rspec --format progress